### PR TITLE
Set player UUID in config of private server request

### DIFF
--- a/src/main/java/rip/bolt/nerve/privateserver/PrivateCommand.java
+++ b/src/main/java/rip/bolt/nerve/privateserver/PrivateCommand.java
@@ -72,7 +72,7 @@ public class PrivateCommand implements Commands {
                 }
 
                 player.sendMessage(Messages.colour(NamedTextColor.GOLD, "Requesting private server..."));
-                if (!requester.request(player.getUsername()))
+                if (!requester.request(player))
                     player.sendMessage(Messages.colour(NamedTextColor.RED, "An error occured while requesting your private server!"));
 
                 return;
@@ -96,7 +96,7 @@ public class PrivateCommand implements Commands {
                 }
 
                 sender.sendMessage(Messages.colour(NamedTextColor.GOLD, "Requesting private server for " + target.getUsername() + "..."));
-                if (!requester.request(target.getUsername()))
+                if (!requester.request(target))
                     sender.sendMessage(Messages.colour(NamedTextColor.RED, "An error occured while requesting a private server!"));
 
                 return;

--- a/src/main/java/rip/bolt/nerve/privateserver/PrivateServerRequester.java
+++ b/src/main/java/rip/bolt/nerve/privateserver/PrivateServerRequester.java
@@ -49,11 +49,14 @@ public class PrivateServerRequester {
         return null;
     }
 
-    public boolean request(String name) {
+    public boolean request(Player player) {
         try {
             KubernetesClient client = new DefaultKubernetesClient();
 
             CustomResourceDefinitionContext context = new CustomResourceDefinitionContext.Builder().withName("helmcharts.helm.cattle.io").withGroup("helm.cattle.io").withScope("Namespaced").withVersion("v1").withPlural("helmcharts").build();
+
+            String name = player.getUsername();
+            String uuid = player.getUniqueId().toString();
 
             Map<String, Object> template = generateTemplate();
             JSONObject helmChartJSONObject = new JSONObject(template);
@@ -65,6 +68,7 @@ public class PrivateServerRequester {
             metadata.put("name", "private-" + name.toLowerCase().replaceAll("_", "-") + "-server");
             setValues.put("config.serverName", name);
             setValues.put("config.operators", name);
+            setValues.put("config.operatorsUuids", uuid);
 
             client.customResource(context).create("minecraft", helmChartJSONObject.toString());
             client.close();


### PR DESCRIPTION
Pass the player UUID to the config. We already have the player UUID at this point and resolving the user UUID by name on server launch sometimes fails. Why not pass it and then use it when creating the server 🤷 .